### PR TITLE
fix: empty custom templates error

### DIFF
--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
@@ -92,7 +93,7 @@ func GetCustomTemplate(filename string) (*template.Template, error) {
 		return t, nil
 	}
 
-	t, err := template.New(filename).Funcs(funcMap).ParseFiles(filename)
+	t, err := template.New(filepath.Base(filename)).Funcs(funcMap).ParseFiles(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/tmpl/tmpl_test.go
+++ b/tmpl/tmpl_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"testing"
 	"time"
+	"path/filepath"
+	"runtime"
 )
 
 func TestFeishuCard(t *testing.T) {
@@ -40,4 +42,25 @@ func newAlerts() template.Data {
 		ExternalURL:       "file://externalUrl",
 		Receiver:          "test-receiver",
 	}
+}
+
+func unittestRelativePath() string {
+	_, file, _, ok := runtime.Caller(1)
+	if !ok {
+		file = ""
+	}
+
+	return filepath.Dir(filepath.FromSlash(file))
+}
+
+func TestGetCustomTemplate(t *testing.T) {
+	require := require.New(t)
+
+	tmpl, err := GetCustomTemplate(filepath.Join(unittestRelativePath(), "templates", "default.tmpl"))
+	require.NoError(err)
+	require.NotNil(tmpl)
+
+	alerts := model.WebhookMessage{Data: newAlerts()}
+	err = tmpl.Execute(os.Stdout, alerts)
+	require.NoError(err)
 }


### PR DESCRIPTION
## Summary

```yaml
bots:
  webhook: # webhook 是 group name
    url: https://open.feishu.cn/open-apis/bot/v2/hook/xx
    template:
      custom_path: templates/default.tmpl
```

```shell
./alertmanager-webhook-feishu server --config=./config.yaml -v
```

When using such config above with the built binary executed, the following error log will be prompted:

```shell
ERRO[2022-09-01T12:56:00+08:00]/home/runner/work/alertmanager-webhook-feishu/alertmanager-webhook-feishu/server/server.go:72 github.com/xujiahua/alertmanager-webhook-feishu/server.Server.hook() cannot send alerts, template: templates/default.tmpl: "templates/default.tmpl" is an incomplete or empty template
```

However, if you change the `bots.template` field in `config.yml` into `default.tmpl`, the error log will no longer be prompted, and the alert message to feishu will be sent as intended.

## Description

This kind of issue appears to be related to missuse of [`template.Template.ParseFiles`](https://pkg.go.dev/html/template#ParseFiles), from its documentations, it says:

> ParseFiles creates a new Template and parses the template definitions from the named files. The returned template's name will have the (base) name and (parsed) contents of the first file. There must be at least one file. If an error occurs, parsing stops and the returned *Template is nil.
When parsing multiple files with the same name in different directories, the last one mentioned will be the one that results. For instance, ParseFiles("a/foo", "b/foo") stores "b/foo" as the template named "foo", while "a/foo" is unavailable.

So when we set the `bots.template` field as `templates/default.tmpl`, the template will be named into `templates/default.tmpl` once `template.Template.New(name string)` has been called.

Afterwards, when `templates/default.tmpl` has passed into `template.Template.ParseFiles(filename ...string)`, the related files would be read and parsed, by referencing [the read from file code used by `template.Template.ParseFiles(filename ...string)`](https://github.com/golang/go/blob/91ef076562dfcf783074dbd84ad7c6db60fdd481/src/text/template/helper.go#L166-L170) from `text/template`, we will see it forced to return a file base name. After getting files parsed and names to be ready, [these code](https://github.com/golang/go/blob/91ef076562dfcf783074dbd84ad7c6db60fdd481/src/text/template/helper.go#L68-L87) will caused the pointer reference of **templates** got lost when `template.Template.Execution` being called.

Since the `*template.Template` instance contains empty template content to reference `templates/default.tmpl` because the pointer never got rewrite and applied with parsed template content, it will throw `template: templates/default.tmpl: "templates/default.tmpl" is an incomplete or empty template` error message as previously stated.

To fix this, we need to keep the `filepath.Base(filename)` behavior the same as `template.Template.ParseFiles(filename ...string)` did.

## References

[embed + text/template: "incomplete or empty template" error with directory · Issue #53751 · golang/go](https://github.com/golang/go/issues/53751)
[template package - html/template - Go Packages](https://pkg.go.dev/html/template#ParseFiles)
[Error "incomplete or empty template" at execute a template](https://groups.google.com/g/golang-nuts/c/L_RaCB3tMaA)